### PR TITLE
Send optional objects

### DIFF
--- a/lib/riskified.rb
+++ b/lib/riskified.rb
@@ -19,6 +19,8 @@ require 'riskified/Entities/line_item'
 require 'riskified/Entities/order'
 require 'riskified/Entities/shipping_line'
 require 'riskified/Entities/recipient'
+require 'riskified/Entities/paypal_details'
+require 'riskified/Entities/credit_card_details'
 
 module Riskified
   class << self

--- a/lib/riskified.rb
+++ b/lib/riskified.rb
@@ -18,6 +18,7 @@ require 'riskified/Entities/discount_code'
 require 'riskified/Entities/line_item'
 require 'riskified/Entities/order'
 require 'riskified/Entities/shipping_line'
+require 'riskified/Entities/recipient'
 
 module Riskified
   class << self

--- a/lib/riskified/Entities/credit_card_details.rb
+++ b/lib/riskified/Entities/credit_card_details.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Riskified
+  module Entities
+
+    ## Reference: https://apiref.riskified.com/curl/#models-payment-details
+    CreditCardDetails = Riskified::Entities::KeywordStruct.new(
+
+        ##### Required #####
+
+        :credit_card_bin,
+        :avs_result_code,
+        :cvv_result_code,
+        :credit_card_number,
+        :credit_card_company,
+
+        #### Optional #####
+
+        :authorization_id,
+        :authorization_error,
+    )
+  end
+end

--- a/lib/riskified/Entities/line_item.rb
+++ b/lib/riskified/Entities/line_item.rb
@@ -19,13 +19,14 @@ module Riskified
         #### Optional #####
 
         :seller, # [Seller]
-        :requires_shippling,
+        :requires_shipping,
         :sku,
         :size,
         :condition,
         :sub_category,
         :delivered_at,
         :delivered_to, # (shipping_address, store_pickup)
+        :recipient, # [Recipient]
     )
 
   end

--- a/lib/riskified/Entities/paypal_details.rb
+++ b/lib/riskified/Entities/paypal_details.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Riskified
+  module Entities
+
+    ## Reference: https://apiref.riskified.com/curl/#models-payment-details
+    PaypalDetails = Riskified::Entities::KeywordStruct.new(
+
+        ##### Required #####
+
+        :payer_email,
+        :payer_status,
+        :payer_address_status,
+        :protection_eligibility,
+
+        #### Optional #####
+
+        :payment_status,
+        :pending_reason,
+        :authorization_id,
+        :authorization_error, # [AuthorizationError]
+    )
+  end
+end

--- a/lib/riskified/Entities/recipient.rb
+++ b/lib/riskified/Entities/recipient.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Riskified
+  module Entities
+
+    ## Reference: https://apiref.riskified.com/curl/#models-recipient
+    Recipient = Riskified::Entities::KeywordStruct.new(
+
+        ##### Required #####
+
+        #### Optional #####
+
+        :email,
+        :phone,
+        :social, # [Social]
+    )
+
+  end
+end


### PR DESCRIPTION
Include `recipient` and `payment-details` optional objects in the request